### PR TITLE
Masaki kaminari edd

### DIFF
--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_next_page.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_next_page.html.haml
@@ -7,6 +7,6 @@
 -#    remote:        data-remote
 %li.page-item.next{ class: "#{'disabled' if current_page.last?}" }
   = link_to (current_page.last? ? "#" : url), class: "page-link", "aria-label" => "Next", :remote => remote do
-    %span{"aria-hidden" => "true"} ›
+    %span{"aria-hidden" => "true"} >>
     %span.sr-only
       = t('views.pagination.next').html_safe

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -16,4 +16,4 @@
         - elsif !page.was_truncated?
           = gap_tag
       = next_page_tag unless current_page.last?
-      = last_page_tag
+      = last_page_tag unless true

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -9,7 +9,7 @@
   %nav
     %ul.pagination
       = first_page_tag unless current_page.first?
-      = prev_page_tag
+      = prev_page_tag unless current_page.first?
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?
           = page_tag page

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -8,7 +8,7 @@
 = paginator.render do
   %nav
     %ul.pagination
-      = first_page_tag
+      = first_page_tag unless current_page.first?
       = prev_page_tag
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -6,7 +6,7 @@
 -#    remote:        data-remote
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
-  %nav.text-xs-center
+  %nav
     %ul.pagination.pagination-sm
       = first_page_tag
       = prev_page_tag

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -7,7 +7,7 @@
 -#    paginator:     the paginator that renders the pagination tags inside
 = paginator.render do
   %nav
-    %ul.pagination.pagination-sm
+    %ul.pagination
       = first_page_tag
       = prev_page_tag
       - each_page do |page|

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -15,5 +15,5 @@
           = page_tag page
         - elsif !page.was_truncated?
           = gap_tag
-      = next_page_tag
+      = next_page_tag unless current_page.last?
       = last_page_tag

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_paginator.html.haml
@@ -8,7 +8,7 @@
 = paginator.render do
   %nav
     %ul.pagination
-      = first_page_tag unless current_page.first?
+      = first_page_tag unless true
       = prev_page_tag unless current_page.first?
       - each_page do |page|
         - if page.left_outer? || page.right_outer? || page.inside_window?

--- a/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_prev_page.html.haml
+++ b/Desktop/team_c/protospace_in_dev-master/app/views/kaminari/_prev_page.html.haml
@@ -7,6 +7,6 @@
 -#    remote:        data-remote
 %li.page-item.prev{ class: "#{'disabled' if current_page.first?}" }
   = link_to (current_page.first? ? "#" : url), class: "page-link", "aria-label" => "Previous", :remote => remote do
-    %span{"aria-hidden" => "true"} ‹
+    %span{"aria-hidden" => "true"} <<
     %span.sr-only
       = t('views.pagination.previous').html_safe


### PR DESCRIPTION
what
ページ送りの機能修正

why
仕様に合わせるため

views/kaminari/_paginator.html.haml　を修正
最初のページにジャンプする＜＜を表示させないように変更
最後のページにジャンプする＞＞を表示させないように変更
戻る＜が最初のページ（１ページ目）では表示されないように変更
次へ＞が最終ページでは表示されないように変更

views/kaminari/_next_page.html.hamlを修正
次への表示を＞から＞＞に変更
戻るの表示を＜から＜＜に変更